### PR TITLE
Fix -s flag printing empty lines

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -50,7 +50,9 @@ func New(opt *option.Options, hostname string) {
 		}
 	}
 
-	fmt.Println(out)
+        if out != "" {
+            fmt.Println(out)
+        }
 }
 
 func writeToFile(data, output string) {


### PR DESCRIPTION
This should fix the empty lines being printed when using the -s flag. 