### PR TITLE
Updated version of const.go following Semantic versioning

### DIFF
--- a/internal/option/const.go
+++ b/internal/option/const.go
@@ -1,7 +1,7 @@
 package option
 
 const (
-  version = "0.1.0"
+  version = "0.1.1"
   author  = "pwnesia.org"
   banner  = `
   ·▄▄▄▄   ▐ ▄ .▄▄ ·▄▄▄▄▄ ▄▄▄· ▄ •▄ ▄▄▄ .


### PR DESCRIPTION
The version didn't update in const.go after patch #24 merged into master and create a release.