### PR TITLE
Update x/sys to fix darwin builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pwnesia/dnstake
 
-go 1.16
+go 1.17
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
@@ -8,4 +8,14 @@ require (
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/retryabledns v1.0.12
 	github.com/remeh/sizedwaitgroup v1.0.0
+)
+
+require (
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/miekg/dns v1.1.29 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,9 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Prevent the darwin build with new golang failing with:
```
# golang.org/x/sys/unix
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:166:3: too many errors
```